### PR TITLE
Add rule to check if Pipfile and Pipfile.lock were modified together

### DIFF
--- a/rules/python-prs.ts
+++ b/rules/python-prs.ts
@@ -53,3 +53,17 @@ export const importStar = wrap("Check if diff contains 'import *'", async () => 
 
   await checkFiles()
 })
+
+export const pipfileLock = wrap("Don't let Pipfile.lock outdated", () => {
+  const files = [...danger.git.modified_files, ...danger.git.created_files]
+  const hasPipfile = files.some(file => {
+    return file == "Pipfile"
+  })
+  const hasPipfileLock = files.some(file => {
+    return file == "Pipfile.lock"
+  })
+
+  if (hasPipfile && !hasPipfileLock) {
+    warn("Pipfile was modified and Pipfile.lock was not. Please update your Python dependencies")
+  }
+})

--- a/tests/pipfile_lock.test.ts
+++ b/tests/pipfile_lock.test.ts
@@ -1,0 +1,32 @@
+jest.mock("danger", () => jest.fn())
+import * as danger from "danger"
+const dm = danger as any
+
+import { pipfileLock } from "../rules/python-prs"
+
+beforeEach(() => {
+  dm.danger = {}
+  dm.warn = jest.fn()
+})
+
+it("warns when Pipfile was modified and Pipfile.lock was not", () => {
+  dm.danger.git = {
+    modified_files: ["Pipfile"],
+  }
+
+  return pipfileLock().then(() => {
+    expect(dm.warn).toHaveBeenCalledWith(
+      "Pipfile was modified and Pipfile.lock was not. Please update your Python dependencies"
+    )
+  })
+})
+
+it("does not warn when both Pipfile and Pipfile.lock were modified", () => {
+  dm.danger.git = {
+    modified_files: ["Pipfile", "Pipfile.lock"],
+  }
+
+  return pipfileLock().then(() => {
+    expect(dm.warn).not.toHaveBeenCalled()
+  })
+})

--- a/tests/pipfile_lock.test.ts
+++ b/tests/pipfile_lock.test.ts
@@ -30,3 +30,13 @@ it("does not warn when both Pipfile and Pipfile.lock were modified", () => {
     expect(dm.warn).not.toHaveBeenCalled()
   })
 })
+
+it("does not warn when both Pipfile and Pipfile.lock were modified", () => {
+  dm.danger.git = {
+    modified_files: ["Something else"],
+  }
+
+  return pipfileLock().then(() => {
+    expect(dm.warn).not.toHaveBeenCalled()
+  })
+})


### PR DESCRIPTION
In order to avoid a modification of `Pipfile` without the corresponding `Pipfile.lock` update, we check if both are being changed in the same PR.