### PR TITLE
rules: add missing Podfile.lock modification

### DIFF
--- a/rules/ios-prs.ts
+++ b/rules/ios-prs.ts
@@ -25,3 +25,13 @@ export const viewFilesWereChanged = wrap("View-ish file changes require a screen
     warn("View files were changed. Maybe you want to add a screenshot to your PR.")
   }
 })
+
+export const podfileLock = wrap("Don't let Podfile.lock outdated", () => {
+  const files = [...danger.git.modified_files, ...danger.git.created_files]
+  const hasPodfile = files.some(file => file == "Podfile")
+  const hasPodfileLock = files.some(file => file == "Podfile.lock")
+
+  if (hasPodfile && !hasPodfileLock) {
+    warn("Podfile was modified and Podfile.lock was not. Please update your lock file.")
+  }
+})

--- a/tests/podfile_lock.test.ts
+++ b/tests/podfile_lock.test.ts
@@ -1,0 +1,40 @@
+jest.mock("danger", () => jest.fn())
+import * as danger from "danger"
+const dm = danger as any
+
+import { podfileLock } from "../rules/ios-prs"
+
+beforeEach(() => {
+  dm.danger = {}
+  dm.warn = jest.fn()
+})
+
+it("warns when Podfile was modified and Podfile.lock was not", () => {
+  dm.danger.git = {
+    modified_files: ["Podfile"],
+  }
+
+  return podfileLock().then(() => {
+    expect(dm.warn).toHaveBeenCalledWith("Podfile was modified and Podfile.lock was not. Please update your lock file.")
+  })
+})
+
+it("does not warn when both Podfile and Podfile.lock were modified", () => {
+  dm.danger.git = {
+    modified_files: ["Podfile", "Podfile.lock"],
+  }
+
+  return podfileLock().then(() => {
+    expect(dm.warn).not.toHaveBeenCalled()
+  })
+})
+
+it("does not warn when neither Podfile nor Podfile.lock were modified", () => {
+  dm.danger.git = {
+    modified_files: ["Dummy.swift"],
+  }
+
+  return podfileLock().then(() => {
+    expect(dm.warn).not.toHaveBeenCalled()
+  })
+})


### PR DESCRIPTION
Later, we can make this more generic and create a rule that would check for similar behaviors. This is currently being repeated for `Gemfile`, `Podfile`, `Pipfile` and `package.json`.