### PR TITLE
Adding merge-on-green label

### DIFF
--- a/rules/release-prs.ts
+++ b/rules/release-prs.ts
@@ -2,6 +2,7 @@ import { schedule, danger, message } from "danger"
 
 export const approveReleasePR = async () => {
   const pr = danger.github.pr
+
   if (pr.title.includes("[Release]")) {
     const api = danger.github.api
     const owner = pr.head.repo.owner.login
@@ -14,6 +15,7 @@ export const approveReleasePR = async () => {
         number: number,
         event: "APPROVE",
       })
+      api.issues.addLabels({ owner, repo, number: number, labels: ["merge-on-green"] })
       await api.pullRequests.merge({ owner, repo, number, commit_title: "Merged by Peril" })
     } catch (e) {
       console.error("Error approving/merging release PR:")

--- a/tests/release-pr.test.ts
+++ b/tests/release-pr.test.ts
@@ -13,6 +13,9 @@ it("Approve and merge a titled release PR", () => {
     git: { commits: [{ message: "Merge branch 'develop'" }] },
     github: {
       api: {
+        issues: {
+          addLabels: jest.fn(),
+        },
         pullRequests: {
           createReview: jest.fn(),
           merge: jest.fn(),
@@ -27,6 +30,7 @@ it("Approve and merge a titled release PR", () => {
   approveReleasePR()
   expect(dm.fail).not.toHaveBeenCalled()
   expect(dm.danger.github.api.pullRequests.createReview).toHaveBeenCalled()
+  expect(dm.danger.github.api.issues.addLabels).toHaveBeenCalled()
   expect(dm.danger.github.api.pullRequests.merge).toHaveBeenCalled()
 })
 
@@ -35,6 +39,9 @@ it("Do not approve and merge an opened PR without release on title", () => {
     git: { commits: [{ message: "Merge branch 'develop'" }] },
     github: {
       api: {
+        issues: {
+          addLabels: jest.fn(),
+        },
         pullRequests: {
           createReview: jest.fn(),
           merge: jest.fn(),
@@ -49,5 +56,6 @@ it("Do not approve and merge an opened PR without release on title", () => {
   approveReleasePR()
   expect(dm.fail).not.toHaveBeenCalled()
   expect(dm.danger.github.api.pullRequests.createReview).not.toHaveBeenCalled()
+  expect(dm.danger.github.api.issues.addLabels).not.toHaveBeenCalled()
   expect(dm.danger.github.api.pullRequests.merge).not.toHaveBeenCalled()
 })


### PR DESCRIPTION
Direct merge fail when the PR is not clean yet (Running tests, etc..), for these cases we are going to add a merge-on-green for later automatic merge.