### PR TITLE
Fix octokit calls

### DIFF
--- a/rules/common/deleteMergedPRBranch.ts
+++ b/rules/common/deleteMergedPRBranch.ts
@@ -14,7 +14,7 @@ const deleteMergedPRBranch = async () => {
   try {
     console.info(`Deleting merged branch ${branch}`)
     const api = danger.github.api
-    await api.gitdata.deleteReference({ owner, repo, ref: `heads/${branch}` })
+    await api.git.deleteRef({ owner, repo, ref: `heads/${branch}` })
     console.info(`Branch ${branch} deleted`)
   } catch (error) {
     console.error(`Error deleting branch ${branch}`)

--- a/rules/common/mergeOnGreen.ts
+++ b/rules/common/mergeOnGreen.ts
@@ -26,7 +26,7 @@ const mergeOnGreen = async () => {
 
   // See https://github.com/maintainers/early-access-feedback/issues/114 for more context on getting a PR from a SHA
   const repoString = danger.github.repository.full_name
-  const searchResponse = await api.search.issues({ q: `${ref} type:pr is:open repo:${repoString}` })
+  const searchResponse = await api.search.issuesAndPullRequests({ q: `${ref} type:pr is:open repo:${repoString}` })
 
   // https://developer.github.com/v3/search/#search-issues
   const prsWithCommit = searchResponse.data.items.map((i: any) => i.number) as number[]


### PR DESCRIPTION
With [this PR](https://github.com/danger/peril/pull/455), the peril from master branch is finally fixed and we should be able to do an update. But this introduces some breaking changes in octokit API, which are adjusted in this PR.