### PR TITLE
do not delete special branches

### DIFF
--- a/rules/common/__tests__/deleteMergedPRBranch.test.ts
+++ b/rules/common/__tests__/deleteMergedPRBranch.test.ts
@@ -1,0 +1,77 @@
+jest.mock("danger", () => jest.fn())
+import * as danger from "danger"
+const dm = danger as any
+
+import deleteMergedPRBranch from "../deleteMergedPRBranch"
+
+it("does not delete special branches", async () => {
+  const mockBranchResponse = (branch: string) =>
+    (dm.danger = {
+      github: {
+        api: {
+          git: {
+            deleteRef: jest.fn(),
+          },
+        },
+        pr: {
+          merged: true,
+          head: {
+            ref: branch,
+          },
+        },
+        thisPR: {},
+      },
+    })
+
+  const specialBranches = ["master", "develop", "production", "staging"]
+
+  await specialBranches.forEach(async branch => {
+    mockBranchResponse(branch)
+    await deleteMergedPRBranch()
+    expect(dm.danger.github.api.git.deleteRef).not.toHaveBeenCalled()
+  })
+})
+
+it("does not delete anything if pr is not merged it", async () => {
+  dm.danger = {
+    github: {
+      api: {
+        git: {
+          deleteRef: jest.fn(),
+        },
+      },
+      pr: {
+        merged: false,
+        head: {
+          ref: "feature/login",
+        },
+      },
+      thisPR: {},
+    },
+  }
+
+  await deleteMergedPRBranch()
+  expect(dm.danger.github.api.git.deleteRef).not.toHaveBeenCalled()
+})
+
+it("should delete other types of branches if they're merged", async () => {
+  dm.danger = {
+    github: {
+      api: {
+        git: {
+          deleteRef: jest.fn(),
+        },
+      },
+      pr: {
+        merged: true,
+        head: {
+          ref: "feature/login",
+        },
+      },
+      thisPR: {},
+    },
+  }
+
+  await deleteMergedPRBranch()
+  expect(dm.danger.github.api.git.deleteRef).toHaveBeenCalled()
+})

--- a/rules/common/deleteMergedPRBranch.ts
+++ b/rules/common/deleteMergedPRBranch.ts
@@ -6,6 +6,13 @@ const deleteMergedPRBranch = async () => {
   const repo = danger.github.thisPR.repo
   const branch = danger.github.pr.head.ref
 
+  const specialBranches = ["master", "develop", "production", "staging"]
+  const isSpecial = specialBranches.includes(branch)
+  if (isSpecial) {
+    console.info(`Bots should not delete special branch "${branch}"`)
+    return
+  }
+
   if (!danger.github.pr.merged) {
     console.info(`Branch ${branch} for PR #${danger.github.thisPR.number} is not merged yet.`)
     return


### PR DESCRIPTION
We should mark special branches as `protected` on GitHub so bot won't accidentally delete them. But this could work as a safeguard.