### PR TITLE
[PLATFORM-1519] Include link to confluence on changelog warning msg

### DIFF
--- a/rules/common/__tests__/changelog.test.ts
+++ b/rules/common/__tests__/changelog.test.ts
@@ -26,7 +26,9 @@ it("warns when code was changed and there is no changelog entry", async () => {
     created_files: [],
   }
   await changelog()
-  expect(dm.warn).toHaveBeenCalledWith("It looks like code was changed without adding anything to the Changelog.")
+  expect(dm.warn).toHaveBeenCalledWith(`It looks like code was changed without adding anything to the Changelog.
+      If you are not sure whether this PR needs a changelog entry you may refer to this [confluence page](https://loadsmart.atlassian.net/wiki/spaces/engineering/pages/800030751/Changelog+entries#What-warrants-a-changelog-entry%3F)
+      `)
 })
 
 it("does not warn when repo has no changelog file", async () => {

--- a/rules/common/changelog.ts
+++ b/rules/common/changelog.ts
@@ -18,7 +18,9 @@ const changelog = async () => {
     const hasChangelogChanges = files.find(file => changelogs_re.test(file))
 
     if (hasCodeChanges && !hasChangelogChanges) {
-      warn("It looks like code was changed without adding anything to the Changelog.")
+      warn(`It looks like code was changed without adding anything to the Changelog.
+      If you are not sure whether this PR needs a changelog entry you may refer to this [confluence page](https://loadsmart.atlassian.net/wiki/spaces/engineering/pages/800030751/Changelog+entries#What-warrants-a-changelog-entry%3F)
+      `)
     }
   }
 }


### PR DESCRIPTION
Includes a link to [confluence page](https://loadsmart.atlassian.net/wiki/spaces/engineering/pages/800030751/Changelog+entries#What-warrants-a-changelog-entry%3F) on the warning message:

![image](https://user-images.githubusercontent.com/8000420/91081122-01fcb480-e61d-11ea-96b2-9687a479e2fa.png)
