### PR TITLE
Add rule for notification hub template changes

### DIFF
--- a/rules/common/__tests__/notificationHubTemplate.test.ts
+++ b/rules/common/__tests__/notificationHubTemplate.test.ts
@@ -1,0 +1,74 @@
+jest.mock("danger", () => jest.fn())
+import * as danger from "danger"
+const dm = danger as any
+
+import notificationHubTemplate from "../notificationHubTemplate"
+
+beforeEach(() => {
+  dm.danger = {}
+  dm.warn = jest.fn()
+})
+
+it("warns when template code was created", async () => {
+  dm.danger.github = {
+    pr: {
+      head: { user: { login: "danger" }, repo: { name: "rfp-backend" } },
+      state: "open",
+    },
+  }
+  dm.danger.git = {
+    modified_files: ["src/new_file.py"],
+    created_files: ["templates/invite_email.html"],
+  }
+  await notificationHubTemplate()
+  expect(dm.warn).toHaveBeenCalledWith(
+    `It looks like code was changed within a template. If the template was for Notification Hub, make sure to update the template in the Admin after merging`
+  )
+})
+
+it("warns when template code was changed", async () => {
+  dm.danger.github = {
+    pr: {
+      head: { user: { login: "danger" }, repo: { name: "rfp-backend" } },
+      state: "open",
+    },
+  }
+  dm.danger.git = {
+    modified_files: ["templates/invite_email.html"],
+    created_files: ["src/new_file.py"],
+  }
+  await notificationHubTemplate()
+  expect(dm.warn).toHaveBeenCalledWith(
+    `It looks like code was changed within a template. If the template was for Notification Hub, make sure to update the template in the Admin after merging`
+  )
+})
+
+it("does not warn when template code was not created/changed", async () => {
+  dm.danger.github = {
+    pr: {
+      head: { user: { login: "danger" }, repo: { name: "rfp-backend" } },
+      state: "open",
+    },
+  }
+  dm.danger.git = {
+    modified_files: ["src/new_file.py"],
+    created_files: ["src/new_file.py"],
+  }
+  await notificationHubTemplate()
+  expect(dm.warn).not.toHaveBeenCalled()
+})
+
+it("does not warn when PR is not open", async () => {
+  dm.danger.github = {
+    pr: {
+      head: { user: { login: "danger" }, repo: { name: "rfp-backend" } },
+      state: "closed",
+    },
+  }
+  dm.danger.git = {
+    modified_files: ["templates/invite_email.html"],
+    created_files: ["templates/invite_email.html"],
+  }
+  await notificationHubTemplate()
+  expect(dm.warn).not.toHaveBeenCalled()
+})

--- a/rules/common/__tests__/notificationHubTemplate.test.ts
+++ b/rules/common/__tests__/notificationHubTemplate.test.ts
@@ -22,7 +22,7 @@ it("warns when template code was created", async () => {
   }
   await notificationHubTemplate()
   expect(dm.warn).toHaveBeenCalledWith(
-    `It looks like code was changed within a template. If the template was for Notification Hub, make sure to update the template in the Admin after merging`
+    `It looks like code was changed within a template. If the template was for Notification Hub, make sure to persist the template change in the Notification Hub Admin after merging!`
   )
 })
 
@@ -39,7 +39,7 @@ it("warns when template code was changed", async () => {
   }
   await notificationHubTemplate()
   expect(dm.warn).toHaveBeenCalledWith(
-    `It looks like code was changed within a template. If the template was for Notification Hub, make sure to update the template in the Admin after merging`
+    `It looks like code was changed within a template. If the template was for Notification Hub, make sure to persist the template change in the Notification Hub Admin after merging!`
   )
 })
 

--- a/rules/common/index.ts
+++ b/rules/common/index.ts
@@ -3,6 +3,7 @@ import workInProgress from "./workInProgress"
 import mergeCommits from "./mergeCommits"
 import changelog from "./changelog"
 import testsUpdated from "./testsUpdated"
+import notificationHubTemplate from "./notificationHubTemplate"
 
 // Default run
 export default async () => {
@@ -11,4 +12,5 @@ export default async () => {
   mergeCommits()
   await changelog()
   testsUpdated()
+  notificationHubTemplate()
 }

--- a/rules/common/notificationHubTemplate.ts
+++ b/rules/common/notificationHubTemplate.ts
@@ -1,6 +1,6 @@
 import { danger, warn } from "danger"
 
-// PRs changing Notification Hub templates should have reminders to update the template on the Notification Hub Adm,in
+// PRs changing Notification Hub templates should have reminders to update the template on the Notification Hub Admin
 const notificationHubTemplate = async () => {
   const isOpen = danger.github.pr.state === "open"
 
@@ -12,7 +12,7 @@ const notificationHubTemplate = async () => {
 
     if (hasTemplateChanges) {
       warn(
-        `It looks like code was changed within a template. If the template was for Notification Hub, make sure to update the template in the Admin after merging`
+        `It looks like code was changed within a template. If the template was for Notification Hub, make sure to persist the template change in the Notification Hub Admin after merging!`
       )
     }
   }

--- a/rules/common/notificationHubTemplate.ts
+++ b/rules/common/notificationHubTemplate.ts
@@ -1,0 +1,21 @@
+import { danger, warn } from "danger"
+
+// PRs changing Notification Hub templates should have reminders to update the template on the Notification Hub Adm,in
+const notificationHubTemplate = async () => {
+  const isOpen = danger.github.pr.state === "open"
+
+  if (isOpen) {
+    const files = [...danger.git.modified_files, ...danger.git.created_files]
+    const templates_re = /(templates\/.*)/
+
+    const hasTemplateChanges = files.find(file => templates_re.test(file))
+
+    if (hasTemplateChanges) {
+      warn(
+        `It looks like code was changed within a template. If the template was for Notification Hub, make sure to update the template in the Admin after merging`
+      )
+    }
+  }
+}
+
+export default notificationHubTemplate

--- a/settings-peril.json
+++ b/settings-peril.json
@@ -23,6 +23,9 @@
         "loadsmart/peril-settings@rules/common/needsDescription.ts",
         "loadsmart/peril-settings@rules/common/testsUpdated.ts"
       ]
+    },
+    "loadsmart/rfp-backend": {
+      "pull_request.opened": ["rules/common/notificationHubTemplate.ts"]
     }
   }
 }


### PR DESCRIPTION
## Description

As part of the Shipper Guide retro, we were asked to add a warning to PRs that are opened that change `template` coding so that we can remind devs to update the template on the Notification Hub admin (since there is no CI to trigger this update automatically when the PR is merged)

## Jira Ticket

https://loadsmart.atlassian.net/browse/SSE-2727