### PR TITLE
fix: ignore changelog check when project has semantic release

### DIFF
--- a/rules/common/__tests__/changelog.test.ts
+++ b/rules/common/__tests__/changelog.test.ts
@@ -110,3 +110,43 @@ it("does not warn when PR is already closed", async () => {
   await changelog()
   expect(dm.warn).not.toHaveBeenCalled()
 })
+
+it("does not warn when repo has changelog file and release.config file", async () => {
+  dm.danger.github = {
+    api: {
+      repos: {
+        getContents: () => Promise.resolve({ data: [{ name: "code.js" }, {name: "release.config.js"}] }),
+      },
+    },
+    pr: {
+      head: { user: { login: "danger" }, repo: { name: "peril-settings" } },
+      state: "open",
+    },
+  }
+  dm.danger.git = {
+    modified_files: ["src/index.html"],
+    created_files: [],
+  }
+  await changelog()
+  expect(dm.warn).not.toHaveBeenCalled()
+})
+
+it("does not warn when repo has changelog and releaserc file", async () => {
+  dm.danger.github = {
+    api: {
+      repos: {
+        getContents: () => Promise.resolve({ data: [{ name: "code.js" }, {name: ".releaserc.yaml"}] }),
+      },
+    },
+    pr: {
+      head: { user: { login: "danger" }, repo: { name: "peril-settings" } },
+      state: "open",
+    },
+  }
+  dm.danger.git = {
+    modified_files: ["src/index.html"],
+    created_files: [],
+  }
+  await changelog()
+  expect(dm.warn).not.toHaveBeenCalled()
+})

--- a/rules/common/changelog.ts
+++ b/rules/common/changelog.ts
@@ -4,14 +4,17 @@ import { danger, warn } from "danger"
 const changelog = async () => {
   const pr = danger.github.pr
   const changelogs_re = /(CHANGELOG.md|changelog.md|CHANGELOG.yml|changelogs\/.*)/
+  const semantic_release_re = /(\.releaserc\.(yaml|yml|json|js|cjs)|release\.config\.(js|cjs))$/
+
   const isOpen = pr.state === "open"
 
   const getContentParams = { path: "", owner: pr.head.user.login, repo: pr.head.repo.name }
   const rootContents: any = await danger.github.api.repos.getContents(getContentParams)
 
   const hasChangelog = rootContents.data.find((file: any) => changelogs_re.test(file.name))
+  const hasSemanticRelease = rootContents.data.find((file: any) => semantic_release_re.test(file.name))
 
-  if (isOpen && hasChangelog) {
+  if (isOpen && hasChangelog && !hasSemanticRelease) {
     const files = [...danger.git.modified_files, ...danger.git.created_files]
 
     const hasCodeChanges = files.find(file => !file.match(/(test|spec)/i))

--- a/rules/common/changelog.ts
+++ b/rules/common/changelog.ts
@@ -8,9 +8,11 @@ const changelog = async () => {
 
   const isOpen = pr.state === "open"
 
-  const packageJson = JSON.parse(await danger.github.utils.fileContents("package.json"))
   const getContentParams = { path: "", owner: pr.head.user.login, repo: pr.head.repo.name }
   const rootContents: any = await danger.github.api.repos.getContents(getContentParams)
+  const packageJson = rootContents.data.find((file: any) => file.name === "package.json")
+      ? JSON.parse(await danger.github.utils.fileContents("package.json"))
+      : {}
 
   const hasChangelog = rootContents.data.find((file: any) => changelogs_re.test(file.name))
   const hasSemanticRelease =

--- a/rules/common/changelog.ts
+++ b/rules/common/changelog.ts
@@ -16,7 +16,8 @@ const changelog = async () => {
 
   const hasChangelog = rootContents.data.find((file: any) => changelogs_re.test(file.name))
   const hasSemanticRelease =
-    rootContents.data.find((file: any) => semantic_release_re.test(file.name)) || packageJson.hasOwnProperty("release")
+    rootContents.data.find((file: any) => semantic_release_re.test(file.name)) ||
+    Object.prototype.hasOwnProperty.call(packageJson, "release")
 
   if (isOpen && hasChangelog && !hasSemanticRelease) {
     const files = [...danger.git.modified_files, ...danger.git.created_files]

--- a/rules/common/changelog.ts
+++ b/rules/common/changelog.ts
@@ -4,15 +4,17 @@ import { danger, warn } from "danger"
 const changelog = async () => {
   const pr = danger.github.pr
   const changelogs_re = /(CHANGELOG.md|changelog.md|CHANGELOG.yml|changelogs\/.*)/
-  const semantic_release_re = /^(\.releaserc\.(yaml|yml|json|js|cjs)|release\.config\.(js|cjs))$/
+  const semantic_release_re = /(\.releaserc\.(yaml|yml|json|js|cjs)|release\.config\.(js|cjs))$/
 
   const isOpen = pr.state === "open"
 
+  const packageJson = JSON.parse(await danger.github.utils.fileContents("package.json"))
   const getContentParams = { path: "", owner: pr.head.user.login, repo: pr.head.repo.name }
   const rootContents: any = await danger.github.api.repos.getContents(getContentParams)
 
   const hasChangelog = rootContents.data.find((file: any) => changelogs_re.test(file.name))
-  const hasSemanticRelease = rootContents.data.find((file: any) => semantic_release_re.test(file.name))
+  const hasSemanticRelease =
+    rootContents.data.find((file: any) => semantic_release_re.test(file.name)) || packageJson.hasOwnProperty("release")
 
   if (isOpen && hasChangelog && !hasSemanticRelease) {
     const files = [...danger.git.modified_files, ...danger.git.created_files]

--- a/rules/common/changelog.ts
+++ b/rules/common/changelog.ts
@@ -4,7 +4,7 @@ import { danger, warn } from "danger"
 const changelog = async () => {
   const pr = danger.github.pr
   const changelogs_re = /(CHANGELOG.md|changelog.md|CHANGELOG.yml|changelogs\/.*)/
-  const semantic_release_re = /(\.releaserc\.(yaml|yml|json|js|cjs)|release\.config\.(js|cjs))$/
+  const semantic_release_re = /^(\.releaserc\.(yaml|yml|json|js|cjs)|release\.config\.(js|cjs))$/
 
   const isOpen = pr.state === "open"
 


### PR DESCRIPTION
if the project has a [semantic-release configuration file](https://github.com/semantic-release/semantic-release/blob/master/docs/usage/configuration.md#configuration) (.releaserc or release.config), Peril ignores it and doesn't check the changelog file. semantic-release already takes care of it with `@semantic-release/changelog` plugin.

notice that the rule won't work if:
- the project holds semantic-release configuration via `release` key in `package.json` file
- the project uses semantic-release without `@semantic-release/changelog`, which is not the case in our organization